### PR TITLE
TalkingView 프레임이 (0, 0)으로 이동하는 버그 수정

### DIFF
--- a/GloomyDiary/Presentation/Component/TalkingView.swift
+++ b/GloomyDiary/Presentation/Component/TalkingView.swift
@@ -43,22 +43,19 @@ extension TalkingView {
     func update(text: String) {
         Task {
             await playTalkingLabelFadeOut()
-            
-            let oldBounds = self.bounds
-            self.talkingLabel.text = text
-            self.layoutIfNeeded()
-            let newBounds = self.bounds
-            
-            let deltaX = oldBounds.width - newBounds.width
-            let deltaY = oldBounds.height - newBounds.height
-            
-            self.frame = oldBounds
-            
-            await playFrameAnimation(CGRect(x: deltaX,
-                                            y: deltaY,
-                                            width: newBounds.width,
-                                            height: newBounds.height))
+            await updateFrame(text: text)
             await playTalkingLabelFadeIn()
+        }
+    }
+    
+    private func updateFrame(text: String) async {
+        return await withCheckedContinuation { continuation in
+            UIView.animate(withDuration: 0.25) {
+                self.talkingLabel.text = text
+                self.superview?.layoutIfNeeded()
+            } completion: { _ in
+                continuation.resume()
+            }
         }
     }
 }


### PR DESCRIPTION
<br>

## 연관 이슈
- #20 

<br>

## 작업 내용
- 메인 말풍선이 애니메이션 도중 (0, 0)으로 이동하는 현상을 제거하였습니다.

<br>

### 스크린샷

![Simulator Screen Recording - iPhone 16 Pro - 2024-11-20 at 02 43 26](https://github.com/user-attachments/assets/0bbab257-531f-4aa3-9568-42595e6c3dcc)



<br>
