### PR TITLE
페이지의 끝에 도달하면 데이터를 로드하지 않도록 수정

### DIFF
--- a/GloomyDiary/Presentation/Screen/History/HistoryList/HistoryListView.swift
+++ b/GloomyDiary/Presentation/Screen/History/HistoryList/HistoryListView.swift
@@ -15,6 +15,7 @@ final class HistoryListView: UIView {
         $0.scrollDirection = .vertical
         $0.minimumLineSpacing = 14
         $0.estimatedItemSize = UICollectionViewFlowLayout.automaticSize
+        $0.sectionInset = .init(top: 0, left: 0, bottom: .verticalValue(70), right: 0)
     }
     
     lazy var collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout).then {

--- a/GloomyDiary/Presentation/Screen/History/HistoryList/HistoryViewController.swift
+++ b/GloomyDiary/Presentation/Screen/History/HistoryList/HistoryViewController.swift
@@ -86,6 +86,8 @@ private extension HistoryViewController {
 
 extension HistoryViewController: UICollectionViewDelegate {
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        if store.isEndOfPage || store.isLoading { return }
+        
         let offsetY = scrollView.contentOffset.y
         let contentHeight = scrollView.contentSize.height
         let frameHeight = scrollView.frame.size.height


### PR DESCRIPTION
<br>

## 연관 이슈
- #87 

<br>

## 작업 내용
- 페이지 끝에 도달하면 더 이상 데이터를 불러오지 않도록 수정했습니다.

<br>